### PR TITLE
A file extension must have word characters at the end

### DIFF
--- a/lib/middleman-aria_current/extension.rb
+++ b/lib/middleman-aria_current/extension.rb
@@ -1,7 +1,7 @@
 require "middleman-core"
 
 class AriaCurrent < ::Middleman::Extension
-  FILE_EXTENSION = /\.(\w*)$/
+  FILE_EXTENSION = /\.(\w+)$/
 
   helpers do
     def current_link_to(*arguments, aria_current: "page", **options, &block)


### PR DESCRIPTION
A file ending in a trailing period is unexpected and therefore not
something we should handle. We should truncate trailing extensions
otherwise.