### PR TITLE
Better path matching via @chrism #15

### DIFF
--- a/lib/middleman-aria_current/extension.rb
+++ b/lib/middleman-aria_current/extension.rb
@@ -1,7 +1,7 @@
 require "middleman-core"
 
 class AriaCurrent < ::Middleman::Extension
-  FILE_EXTENSION = /\.(\w+)$/
+  FILE_EXTENSION = /\.(\w*)$/
 
   helpers do
     def current_link_to(*arguments, aria_current: "page", **options, &block)
@@ -16,7 +16,7 @@ class AriaCurrent < ::Middleman::Extension
       link_options = options
       current_path = current_page.url.to_s.gsub(FILE_EXTENSION, "")
 
-      if current_path == path
+      if current_path.include? path
         link_options.merge!("aria-current" => aria_current)
       end
 


### PR DESCRIPTION
Referencing issue #15 on line 19:

`if current_path.include? path`

Works in my tests, and the explicit match before did not work.