### PR TITLE
Trim trailing slash from `current_path`

### DIFF
--- a/lib/middleman-aria_current/extension.rb
+++ b/lib/middleman-aria_current/extension.rb
@@ -4,7 +4,7 @@ class AriaCurrent < ::Middleman::Extension
   FILE_EXTENSION = /\.(\w+)$/
 
   helpers do
-    def current_link_to(*arguments, aria_current: "page", **options, &block)
+    def current_link_to(*arguments, aria_current: "page", debug: false, **link_options, &block)
       if block_given?
         text = capture(&block)
         path = arguments[0]
@@ -13,14 +13,14 @@ class AriaCurrent < ::Middleman::Extension
         path = arguments[1]
       end
 
-      link_options = options
-      current_path = current_page.url.to_s.gsub(FILE_EXTENSION, "")
+      current_path = current_page.url.to_s.
+        gsub(FILE_EXTENSION, "").
+        chomp("/")
 
-      if current_path == path
-        link_options.merge!("aria-current" => aria_current)
-      end
+      link_options["aria-current"] = aria_current if current_path == path
+      link_options["data-current-path"] = current_path if debug
 
-      link_to(text, path, link_options)
+      link_to text, path, link_options
     end
   end
 end


### PR DESCRIPTION
This resolves issues where linking to `/about` fails to match the `current_page.url` for a directory index (`/about/`). 

I also added a simple `debug` option to the arguments that will add a `data-current-path` attribute to the generated link to aide in diagnosing issues where middleman-aria_current doesn't behave as expected:

```erb
<%= current_link_to "About", "/about', debug: true %>
```
```html
<a href="/about" data-current-page="/about">About</a>
```