### PR TITLE
Resolve "current" through sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
   [Keep a Changelog]: http://keepachangelog.com/
   [Semantic Versioning]: http://semver.org/
 
+## master
+
+- Instead of determining the "current" resource through `String` comparison
+  (including incorporating the resource file's extension), make use of the
+  [`sitemap`][sitemap].
+
+  [sitemap]: [sitemap]: https://middlemanapp.com/advanced/sitemap/#accessing-the-sitemap-from-code
+
+
 ## [0.1.1] - 2017-03-19
 
 ### Changed

--- a/lib/middleman-aria_current/extension.rb
+++ b/lib/middleman-aria_current/extension.rb
@@ -1,8 +1,6 @@
 require "middleman-core"
 
 class AriaCurrent < ::Middleman::Extension
-  FILE_EXTENSION = /\.(\w+)$/
-
   helpers do
     def current_link_to(*arguments, aria_current: "page", **options, &block)
       if block_given?
@@ -14,9 +12,10 @@ class AriaCurrent < ::Middleman::Extension
       end
 
       link_options = options
-      current_path = current_page.url.to_s.gsub(FILE_EXTENSION, "")
 
-      if current_path == path
+      uri = URI.parse(path.to_s)
+
+      if current_resource == sitemap.find_resource_by_path(uri.path)
         link_options.merge!("aria-current" => aria_current)
       end
 


### PR DESCRIPTION
Instead of determining the "current" resource through `String`
comparison (including incorporating the resource file's extension), make
use of the [`sitemap`][sitemap].

According to the Middleman documentation:

> Each resource in the sitemap is a [Resource] object. Resources can
> tell you all kinds of interesting things about themselves. You can
> access frontmatter data, file extension, source and output paths, a
> linkable URL, etc.

When generating pages, the extension compares the `current_resource`
(which is aliased to [`current_page`][current_page]) with the resource
that corresponds to the [`link_to`][link_to] call's `path` argument.

So long as the `path` to the `link_to` call corresponds to a page that
Middleman has built, the Sitemap will resolve the resource, _including_
if the `link_to` call is made with the `relative: true` option -- either
directly, or with `set :relative_links, true` in `config.rb`.

[sitemap]: https://middlemanapp.com/advanced/sitemap/#accessing-the-sitemap-from-code
[Resource]: https://www.rubydoc.info/gems/middleman-core/Middleman/Sitemap/Resource
[current_page]: https://github.com/middleman/middleman/blob/v4.3.5/middleman-core/lib/middleman-core/template_context.rb#L168-L174
[link_to]: https://middlemanapp.com/basics/helper-methods/#link-helpers