### PR TITLE
Yield `ERB` block as contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 
 ## master
 
+- Yield block as contents 
+
 - Instead of determining the "current" resource through `String` comparison
   (including incorporating the resource file's extension), make use of the
   [`sitemap`][sitemap].

--- a/lib/middleman-aria_current/extension.rb
+++ b/lib/middleman-aria_current/extension.rb
@@ -4,14 +4,12 @@ class AriaCurrent < ::Middleman::Extension
   helpers do
     def current_link_to(*arguments, aria_current: "page", **options, &block)
       if block_given?
-        text = capture(&block)
         path = arguments[0]
       else
-        text = arguments[0]
         path = arguments[1]
       end
 
-      link_options = options
+      link_options = options.dup
 
       uri = URI.parse(path.to_s)
 
@@ -19,7 +17,7 @@ class AriaCurrent < ::Middleman::Extension
         link_options.merge!("aria-current" => aria_current)
       end
 
-      link_to(text, path, link_options)
+      link_to(*arguments, link_options, &block)
     end
   end
 end


### PR DESCRIPTION
Invoke the `link_to` helper with the original arguments, save for the
modified `options` Hash.

Prior to this commit, the `current_link_to` helper was unable to yield
a block and [capture] the contents to be rendered as children to the
resulting [`<a>` element][mdn-a].

The presence or absence of the [`&block` as an argument][ruby-block] is
_only_ useful to determine which index in the argument list references
the `link_to` invocation's desired `path` value.

Since the `text` (or contents of the [`yield`-ed][ruby-yield] block) is
unmodified, we can delegate to the underlying `link_to` helper with the
original ["splatted" `*arguments` value][ruby-splat].

[capture]: https://middlemanapp.com/basics/helper-methods/#output-helpers
[mdn-a]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
[ruby-block]: https://ruby-doc.org/core-2.6/Proc.html#class-Proc-label-Creation
[ruby-yield]: https://ruby-doc.org/core-2.2.0/doc/syntax/calling_methods_rdoc.html#label-Proc+to+Block+Conversion
[ruby-splat]: https://ruby-doc.org/core-2.2.0/doc/syntax/calling_methods_rdoc.html#label-Array+to+Arguments+Conversion